### PR TITLE
FIX: Syntax and settings issues

### DIFF
--- a/javascripts/discourse/components/modal/insert-jitsi.gjs
+++ b/javascripts/discourse/components/modal/insert-jitsi.gjs
@@ -5,7 +5,6 @@ import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
 import DModal from "discourse/components/d-modal";
 import TextField from "discourse/components/text-field";
-import themePrefix from "discourse/helpers/theme-prefix";
 import i18n from "discourse-common/helpers/i18n";
 
 export default class InsertJitsi extends Component {

--- a/javascripts/discourse/components/modal/insert-jitsi.gjs
+++ b/javascripts/discourse/components/modal/insert-jitsi.gjs
@@ -1,3 +1,5 @@
+/*eslint no-undef:0 */
+
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";

--- a/javascripts/discourse/initializers/insert-jitsi.js
+++ b/javascripts/discourse/initializers/insert-jitsi.js
@@ -1,3 +1,4 @@
+/*eslint no-undef:0 */
 /* global JitsiMeetExternalAPI */
 import loadScript from "discourse/lib/load-script";
 import { withPluginApi } from "discourse/lib/plugin-api";

--- a/javascripts/discourse/initializers/insert-jitsi.js
+++ b/javascripts/discourse/initializers/insert-jitsi.js
@@ -1,5 +1,4 @@
 /* global JitsiMeetExternalAPI */
-import themePrefix from "discourse/helpers/theme-prefix";
 import loadScript from "discourse/lib/load-script";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { iconHTML } from "discourse-common/lib/icon-library";

--- a/javascripts/discourse/initializers/insert-jitsi.js
+++ b/javascripts/discourse/initializers/insert-jitsi.js
@@ -74,10 +74,9 @@ export default {
     withPluginApi("0.8.31", (api) => {
       const currentUser = api.getCurrentUser();
       const modal = api.container.lookup("service:modal");
-      const settings = api.container.lookup("site-settings:main");
 
       if (settings.show_in_options_dropdown) {
-        if (settings.only_available_to_staff && currentUser?.staff) {
+        if (!settings.only_available_to_staff || currentUser?.staff) {
           api.addComposerToolbarPopupMenuOption({
             icon: settings.button_icon,
             label: themePrefix("composer_title"),


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/discourse-jitsi-component-not-working/290861
Followup https://github.com/discourse/discourse-jitsi/pull/20

This PR fixes two issues:
* `Identifier ‘themePrefix’ has already been declared`; `themePrefix` function already exists in a component context.
* The theme settings are not working because the site settings lookup overwrote them. There is also a logic issue with the `show_in_options_dropdown` setting, where we want to show the button if `only_available_to_staff` is not checked or the user is a staff only.

Tests would be welcomed, but I'm not good enough yet to make them correctly and fast.
