### PR TITLE
DEV: Update post-stream detection following core change

### DIFF
--- a/javascripts/discourse/initializers/insert-jitsi.js
+++ b/javascripts/discourse/initializers/insert-jitsi.js
@@ -58,7 +58,7 @@ function attachButton($elem, user, site) {
 }
 
 function attachJitsi($elem, helper) {
-  if (helper) {
+  if (helper?.getModel()) {
     const { currentUser, site } = helper.widget;
 
     $elem.find("[data-wrap=discourse-jitsi]").each((idx, val) => {


### PR DESCRIPTION
> The helper is now available in all decoration locations, so we should gate this logic on the presence of the post model instead. -- David

This PR fixes the following error when the composer is open:

![image](https://github.com/user-attachments/assets/af231a67-071b-449b-8eb9-75e3095ce593)
